### PR TITLE
2018 Tourney Updates & a few loose ends

### DIFF
--- a/Rewards-2019-Aug-12.xml
+++ b/Rewards-2019-Aug-12.xml
@@ -37,11 +37,6 @@
                 <Field Id="Rewards"/>
             </Int>
         </Instances>
-        <Instances Id="1-S2-1-8560622">
-            <Int Int="3">
-                <Field Id="Rewards"/>
-            </Int>
-        </Instances>
         <Instances Id="1-S2-1-10194067My">
             <Int Int="3">
                 <Field Id="Rewards"/>
@@ -161,7 +156,7 @@
             </String>
         </Instances>
         <Instances Id="1-S2-1-2595230">
-            <String String="0 0 0 1 6 0">
+            <String String="0 0 0 1 6 4224">
                 <Field Id="Rewards"/>
             </String>
         </Instances>
@@ -1732,6 +1727,11 @@
         </Instances>
         <Instances Id="1-S2-1-473106">
             <String String="0 0 0 0 2 0">
+                <Field Id="Rewards"/>
+            </String>
+        </Instances>
+         <Instances Id="1-S2-1-856062">
+            <String String="0 1 2 2 4 0">
                 <Field Id="Rewards"/>
             </String>
         </Instances>
@@ -5096,7 +5096,7 @@
             </String>
         </Instances>
         <Instances Id="1-S2-1-3540180">
-            <String String="0 2 0 0 6 7111">
+            <String String="0 2 0 0 6 77">
                 <Field Id="Rewards"/>
             </String>
         </Instances>
@@ -9017,6 +9017,16 @@
         </Instances>
         <Instances Id="1-S2-1-20469926">
             <String String="0 1 0 0 1 4098">
+                <Field Id="Rewards"/>
+            </String>
+        </Instances>
+        <Instances Id="1-s2-1-8553688">
+            <String String="1 0 0 0 1 4224">
+                <Field Id="Rewards"/>
+            </String>
+        </Instances>
+        <Instances Id="1-S2-1-8560622">
+            <String String="1 0 0 0 3 4224">
                 <Field Id="Rewards"/>
             </String>
         </Instances>


### PR DESCRIPTION
Updates for Fury (2018 tournament), AmarUtu (restoring old skins), and CriscoCube (restoring old skins/stars).

Also changed Helvetican to '77' to check what rewards this # gives.